### PR TITLE
[codex] Fix Turbopack workspace root detection

### DIFF
--- a/cook-scan/next.config.ts
+++ b/cook-scan/next.config.ts
@@ -1,8 +1,15 @@
 import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@mastra/*"],
+  turbopack: {
+    root: projectRoot,
+  },
   typedRoutes: true,
 };
 


### PR DESCRIPTION
## Summary

- Set `turbopack.root` in `cook-scan/next.config.ts` to the Next.js project directory.
- Resolve the root from the config file path so builds do not depend on the shell working directory.

## Why

Next.js was detecting multiple lockfiles and selecting `/Users/aberyouta/package-lock.json` as the workspace root during build. Pinning the Turbopack root to this app removes that warning and keeps build root detection stable.

## Validation

- `vp run build`
- `vp check`
- `vp test`