### PR TITLE
AIレシピ生成を対話型で追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate Prisma Client
+        run: pnpm run db:generate
+
       - name: Lint
         run: pnpm run lint
 

--- a/cook-scan/src/app/api/recipes/generate/route.test.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
 import type { NextRequest } from "next/server";
-import { generateText } from "ai";
+import { generateObject } from "ai";
 import { POST } from "./route";
 
 vi.mock("ai", () => ({
-  generateText: vi.fn(),
+  generateObject: vi.fn(),
 }));
 
 vi.mock("@/backend/ai/models/openai", () => ({
@@ -22,10 +22,19 @@ describe("POST /api/recipes/generate", () => {
     consoleErrorSpy.mockClear();
   });
 
-  it("returns generated markdown", async () => {
-    vi.mocked(generateText).mockResolvedValueOnce({
-      text: "この材料なら作れます。\n\n## レシピ名\n卵チャーハン",
-    } as Awaited<ReturnType<typeof generateText>>);
+  it("returns generated recipe draft", async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce({
+      object: {
+        message: "卵チャーハンの下書きを作りました。",
+        intent: "recipe_draft",
+        recipeDraft: {
+          title: "卵チャーハン",
+          ingredients: [{ name: "卵", unit: "1個", notes: null }],
+          steps: [{ instruction: "卵を炒める", timerSeconds: null }],
+          memo: "足りないもの: なし",
+        },
+      },
+    } as Awaited<ReturnType<typeof generateObject>>);
 
     const response = await POST(
       new Request("http://localhost/api/recipes/generate", {
@@ -41,10 +50,17 @@ describe("POST /api/recipes/generate", () => {
     expect(body).toEqual({
       status: "success",
       result: {
-        markdown: "この材料なら作れます。\n\n## レシピ名\n卵チャーハン",
+        message: "卵チャーハンの下書きを作りました。",
+        intent: "recipe_draft",
+        recipeDraft: {
+          title: "卵チャーハン",
+          ingredients: [{ name: "卵", unit: "1個", notes: null }],
+          steps: [{ instruction: "卵を炒める", timerSeconds: null }],
+          memo: "足りないもの: なし",
+        },
       },
     });
-    expect(generateText).toHaveBeenCalledWith(
+    expect(generateObject).toHaveBeenCalledWith(
       expect.objectContaining({
         model: "mock-openai-model",
         prompt: "ユーザー:\n卵とご飯で簡単に作りたい",
@@ -53,9 +69,13 @@ describe("POST /api/recipes/generate", () => {
   });
 
   it("passes conversation history to prompt", async () => {
-    vi.mocked(generateText).mockResolvedValueOnce({
-      text: "時短版にします。",
-    } as Awaited<ReturnType<typeof generateText>>);
+    vi.mocked(generateObject).mockResolvedValueOnce({
+      object: {
+        message: "時短版にします。",
+        intent: "chat",
+        recipeDraft: null,
+      },
+    } as Awaited<ReturnType<typeof generateObject>>);
 
     await POST(
       new Request("http://localhost/api/recipes/generate", {
@@ -70,7 +90,7 @@ describe("POST /api/recipes/generate", () => {
       }) as NextRequest,
     );
 
-    expect(generateText).toHaveBeenCalledWith(
+    expect(generateObject).toHaveBeenCalledWith(
       expect.objectContaining({
         prompt:
           "ユーザー:\n鶏肉で作りたい\n\n---\n\nアシスタント:\n## レシピ名\n鶏肉炒め\n\n---\n\nユーザー:\nもっと時短にして",
@@ -89,11 +109,11 @@ describe("POST /api/recipes/generate", () => {
 
     expect(response.status).toBe(400);
     expect(body.status).toBe("error");
-    expect(generateText).not.toHaveBeenCalled();
+    expect(generateObject).not.toHaveBeenCalled();
   });
 
   it("returns 500 when generation fails", async () => {
-    vi.mocked(generateText).mockRejectedValueOnce(new Error("AI error"));
+    vi.mocked(generateObject).mockRejectedValueOnce(new Error("AI error"));
 
     const response = await POST(
       new Request("http://localhost/api/recipes/generate", {

--- a/cook-scan/src/app/api/recipes/generate/route.test.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
+import type { NextRequest } from "next/server";
+import { generateText } from "ai";
+import { POST } from "./route";
+
+vi.mock("ai", () => ({
+  generateText: vi.fn(),
+}));
+
+vi.mock("@/backend/ai/models/openai", () => ({
+  openaiGpt: "mock-openai-model",
+}));
+
+describe("POST /api/recipes/generate", () => {
+  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockClear();
+  });
+
+  it("returns generated markdown", async () => {
+    vi.mocked(generateText).mockResolvedValueOnce({
+      text: "この材料なら作れます。\n\n## レシピ名\n卵チャーハン",
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    const response = await POST(
+      new Request("http://localhost/api/recipes/generate", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "卵とご飯で簡単に作りたい" }],
+        }),
+      }) as NextRequest,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      status: "success",
+      result: {
+        markdown: "この材料なら作れます。\n\n## レシピ名\n卵チャーハン",
+      },
+    });
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "mock-openai-model",
+        prompt: "ユーザー:\n卵とご飯で簡単に作りたい",
+      }),
+    );
+  });
+
+  it("passes conversation history to prompt", async () => {
+    vi.mocked(generateText).mockResolvedValueOnce({
+      text: "時短版にします。",
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    await POST(
+      new Request("http://localhost/api/recipes/generate", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            { role: "user", content: "鶏肉で作りたい" },
+            { role: "assistant", content: "## レシピ名\n鶏肉炒め" },
+            { role: "user", content: "もっと時短にして" },
+          ],
+        }),
+      }) as NextRequest,
+    );
+
+    expect(generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt:
+          "ユーザー:\n鶏肉で作りたい\n\n---\n\nアシスタント:\n## レシピ名\n鶏肉炒め\n\n---\n\nユーザー:\nもっと時短にして",
+      }),
+    );
+  });
+
+  it("returns 400 when prompt is invalid", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/recipes/generate", {
+        method: "POST",
+        body: JSON.stringify({ messages: [] }),
+      }) as NextRequest,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.status).toBe("error");
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when generation fails", async () => {
+    vi.mocked(generateText).mockRejectedValueOnce(new Error("AI error"));
+
+    const response = await POST(
+      new Request("http://localhost/api/recipes/generate", {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "鶏肉と玉ねぎで作りたい" }],
+        }),
+      }) as NextRequest,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({
+      status: "error",
+      error: "レシピ生成に失敗しました",
+    });
+  });
+});

--- a/cook-scan/src/app/api/recipes/generate/route.test.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.test.ts
@@ -33,6 +33,7 @@ describe("POST /api/recipes/generate", () => {
           steps: [{ instruction: "卵を炒める", timerSeconds: null }],
           memo: "足りないもの: なし",
         },
+        suggestions: ["もっと時短にする", "買い足しなしにする"],
       },
     } as Awaited<ReturnType<typeof generateObject>>);
 
@@ -58,6 +59,7 @@ describe("POST /api/recipes/generate", () => {
           steps: [{ instruction: "卵を炒める", timerSeconds: null }],
           memo: "足りないもの: なし",
         },
+        suggestions: ["もっと時短にする", "買い足しなしにする"],
       },
     });
     expect(generateObject).toHaveBeenCalledWith(
@@ -74,6 +76,7 @@ describe("POST /api/recipes/generate", () => {
         message: "時短版にします。",
         intent: "chat",
         recipeDraft: null,
+        suggestions: ["さらに簡単にする"],
       },
     } as Awaited<ReturnType<typeof generateObject>>);
 

--- a/cook-scan/src/app/api/recipes/generate/route.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.ts
@@ -3,16 +3,21 @@ import { generateObject } from "ai";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
+const USER_ROLE = "user";
+const ASSISTANT_ROLE = "assistant";
+const MESSAGE_ROLES = [USER_ROLE, ASSISTANT_ROLE] as const;
+const MAX_SUGGESTION_COUNT = 4;
+
 const requestSchema = z.object({
   messages: z
     .array(
       z.object({
-        role: z.enum(["user", "assistant"]),
+        role: z.enum(MESSAGE_ROLES),
         content: z.string().trim().min(1),
       }),
     )
     .min(1, "messagesは1件以上必要です")
-    .refine((messages) => messages[messages.length - 1]?.role === "user", {
+    .refine((messages) => messages[messages.length - 1]?.role === USER_ROLE, {
       message: "最後のメッセージはuserである必要があります",
     }),
 });
@@ -43,11 +48,11 @@ const responseSchema = z.object({
   message: z.string(),
   intent: z.enum(["chat", "recipe_draft"]),
   recipeDraft: recipeDraftSchema.nullable(),
-  suggestions: z.array(z.string().min(1)).min(1).max(4),
+  suggestions: z.array(z.string().min(1)).min(1).max(MAX_SUGGESTION_COUNT),
 });
 
 const systemPrompt = `
-あなたは家庭料理に強いAIレシピアシスタントです。
+あなたはレシピ作成に強いAIレシピアシスタントです。
 必ず日本語で回答してください。
 ユーザーの手持ち食材、希望、制約をもとに、実際に作りやすいレシピを1つ提案してください。
 会話履歴がある場合は、直前までの提案内容を踏まえて調整してください。
@@ -71,13 +76,14 @@ const systemPrompt = `
 
 function buildConversationPrompt(
   messages: Array<{
-    role: "user" | "assistant";
+    role: (typeof MESSAGE_ROLES)[number];
     content: string;
   }>,
 ) {
+  // User/assistant labels and separators preserve turn order for follow-up recipe adjustments.
   return messages
     .map((message) => {
-      const speaker = message.role === "user" ? "ユーザー" : "アシスタント";
+      const speaker = message.role === USER_ROLE ? "ユーザー" : "アシスタント";
       return `${speaker}:\n${message.content}`;
     })
     .join("\n\n---\n\n");
@@ -92,6 +98,7 @@ export async function POST(request: NextRequest) {
       schema: responseSchema,
       system: systemPrompt,
       prompt: buildConversationPrompt(body.messages),
+      // Keep enough variation for recipe ideation while schema validation keeps the output usable.
       temperature: 0.7,
     });
 

--- a/cook-scan/src/app/api/recipes/generate/route.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.ts
@@ -1,0 +1,93 @@
+import { openaiGpt } from "@/backend/ai/models/openai";
+import { generateText } from "ai";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const requestSchema = z.object({
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(["user", "assistant"]),
+        content: z.string().trim().min(1),
+      }),
+    )
+    .min(1, "messagesは1件以上必要です")
+    .refine((messages) => messages[messages.length - 1]?.role === "user", {
+      message: "最後のメッセージはuserである必要があります",
+    }),
+});
+
+const systemPrompt = `
+あなたは家庭料理に強いAIレシピアシスタントです。
+必ず日本語で回答してください。
+ユーザーの手持ち食材、希望、制約をもとに、実際に作りやすいレシピを1つ提案してください。
+会話履歴がある場合は、直前までの提案内容を踏まえて調整してください。
+
+出力はMarkdown調のプレーンテキストにしてください。
+コードフェンスやJSONは出力しないでください。
+
+必ず以下の要素を含めてください。
+- 短い会話文
+- レシピ名
+- 材料
+- 作り方
+- 足りないもの
+- アレンジ案
+
+方針:
+- 手持ち食材をできるだけ優先する
+- 足りないものがない場合は「足りないもの: なし」と書く
+- 作り方は初心者でも分かる粒度にする
+- 危険な調理や衛生的に問題のある提案はしない
+`;
+
+function buildConversationPrompt(
+  messages: Array<{
+    role: "user" | "assistant";
+    content: string;
+  }>,
+) {
+  return messages
+    .map((message) => {
+      const speaker = message.role === "user" ? "ユーザー" : "アシスタント";
+      return `${speaker}:\n${message.content}`;
+    })
+    .join("\n\n---\n\n");
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = requestSchema.parse(await request.json());
+
+    const { text } = await generateText({
+      model: openaiGpt,
+      system: systemPrompt,
+      prompt: buildConversationPrompt(body.messages),
+      temperature: 0.7,
+    });
+
+    return NextResponse.json(
+      {
+        status: "success",
+        result: {
+          markdown: text.trim(),
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error(error);
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { status: "error", error: error.issues[0]?.message ?? "入力内容が不正です" },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      { status: "error", error: "レシピ生成に失敗しました" },
+      { status: 500 },
+    );
+  }
+}

--- a/cook-scan/src/app/api/recipes/generate/route.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.ts
@@ -39,6 +39,7 @@ const responseSchema = z.object({
   message: z.string(),
   intent: z.enum(["chat", "recipe_draft"]),
   recipeDraft: recipeDraftSchema.nullable(),
+  suggestions: z.array(z.string()).min(1).max(4),
 });
 
 const systemPrompt = `
@@ -53,6 +54,7 @@ const systemPrompt = `
 - message: チャット吹き出しに表示する短い自然な返答
 - intent: レシピ下書きを作る場合は "recipe_draft"、質問への返答だけなら "chat"
 - recipeDraft: intent が "recipe_draft" の場合だけレシピ下書きを入れる。intent が "chat" の場合は null
+- suggestions: 次にユーザーが押せる短い提案を1〜4件。会話内容や作成したレシピに合わせて毎回変える
 
 方針:
 - ユーザーがレシピ作成、献立提案、材料から料理を作る相談、既存提案の調整を求めたら recipe_draft にする

--- a/cook-scan/src/app/api/recipes/generate/route.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.ts
@@ -18,20 +18,24 @@ const requestSchema = z.object({
 });
 
 const recipeDraftSchema = z.object({
-  title: z.string(),
-  ingredients: z.array(
-    z.object({
-      name: z.string(),
-      unit: z.string(),
-      notes: z.string().nullable(),
-    }),
-  ),
-  steps: z.array(
-    z.object({
-      instruction: z.string(),
-      timerSeconds: z.number().nullable(),
-    }),
-  ),
+  title: z.string().min(1),
+  ingredients: z
+    .array(
+      z.object({
+        name: z.string().min(1),
+        unit: z.string().min(1),
+        notes: z.string().nullable(),
+      }),
+    )
+    .min(1),
+  steps: z
+    .array(
+      z.object({
+        instruction: z.string().min(1),
+        timerSeconds: z.number().nullable(),
+      }),
+    )
+    .min(1),
   memo: z.string().nullable(),
 });
 
@@ -39,7 +43,7 @@ const responseSchema = z.object({
   message: z.string(),
   intent: z.enum(["chat", "recipe_draft"]),
   recipeDraft: recipeDraftSchema.nullable(),
-  suggestions: z.array(z.string()).min(1).max(4),
+  suggestions: z.array(z.string().min(1)).min(1).max(4),
 });
 
 const systemPrompt = `

--- a/cook-scan/src/app/api/recipes/generate/route.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.ts
@@ -1,5 +1,5 @@
 import { openaiGpt } from "@/backend/ai/models/openai";
-import { generateText } from "ai";
+import { generateObject } from "ai";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -17,26 +17,48 @@ const requestSchema = z.object({
     }),
 });
 
+const recipeDraftSchema = z.object({
+  title: z.string(),
+  ingredients: z.array(
+    z.object({
+      name: z.string(),
+      unit: z.string(),
+      notes: z.string().nullable(),
+    }),
+  ),
+  steps: z.array(
+    z.object({
+      instruction: z.string(),
+      timerSeconds: z.number().nullable(),
+    }),
+  ),
+  memo: z.string().nullable(),
+});
+
+const responseSchema = z.object({
+  message: z.string(),
+  intent: z.enum(["chat", "recipe_draft"]),
+  recipeDraft: recipeDraftSchema.nullable(),
+});
+
 const systemPrompt = `
 あなたは家庭料理に強いAIレシピアシスタントです。
 必ず日本語で回答してください。
 ユーザーの手持ち食材、希望、制約をもとに、実際に作りやすいレシピを1つ提案してください。
 会話履歴がある場合は、直前までの提案内容を踏まえて調整してください。
 
-出力はMarkdown調のプレーンテキストにしてください。
-コードフェンスやJSONは出力しないでください。
+出力は指定された構造だけにしてください。
 
-必ず以下の要素を含めてください。
-- 短い会話文
-- レシピ名
-- 材料
-- 作り方
-- 足りないもの
-- アレンジ案
+フィールドの方針:
+- message: チャット吹き出しに表示する短い自然な返答
+- intent: レシピ下書きを作る場合は "recipe_draft"、質問への返答だけなら "chat"
+- recipeDraft: intent が "recipe_draft" の場合だけレシピ下書きを入れる。intent が "chat" の場合は null
 
 方針:
+- ユーザーがレシピ作成、献立提案、材料から料理を作る相談、既存提案の調整を求めたら recipe_draft にする
 - 手持ち食材をできるだけ優先する
-- 足りないものがない場合は「足りないもの: なし」と書く
+- 不足食材や補足は recipeDraft.memo に含める
+- 材料の分量が不明な場合は unit に「適量」と書く
 - 作り方は初心者でも分かる粒度にする
 - 危険な調理や衛生的に問題のある提案はしない
 `;
@@ -59,8 +81,9 @@ export async function POST(request: NextRequest) {
   try {
     const body = requestSchema.parse(await request.json());
 
-    const { text } = await generateText({
+    const { object } = await generateObject({
       model: openaiGpt,
+      schema: responseSchema,
       system: systemPrompt,
       prompt: buildConversationPrompt(body.messages),
       temperature: 0.7,
@@ -69,9 +92,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       {
         status: "success",
-        result: {
-          markdown: text.trim(),
-        },
+        result: object,
       },
       { status: 200 },
     );

--- a/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
+++ b/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
@@ -37,7 +37,8 @@ describe("AiRecipeGenerator", () => {
     render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     expect(screen.getByText("AIで献立・レシピ提案")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/)).toBeInTheDocument();
+    expect(screen.getByText(/冷蔵庫にある食材や/)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/鶏むね肉、玉ねぎ、卵/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /レシピを提案/ })).toBeInTheDocument();
   });
 
@@ -67,7 +68,7 @@ describe("AiRecipeGenerator", () => {
     render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     await user.type(
-      screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
+      screen.getByPlaceholderText(/鶏むね肉、玉ねぎ、卵/),
       "鶏むね肉と卵で20分以内の夕飯にしたい",
     );
     await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
@@ -108,7 +109,7 @@ describe("AiRecipeGenerator", () => {
     render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     await user.type(
-      screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
+      screen.getByPlaceholderText(/鶏むね肉、玉ねぎ、卵/),
       "鶏むね肉と卵で20分以内の夕飯にしたい",
     );
     await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
@@ -142,7 +143,7 @@ describe("AiRecipeGenerator", () => {
     render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     await user.type(
-      screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
+      screen.getByPlaceholderText(/鶏むね肉、玉ねぎ、卵/),
       "鶏むね肉と卵で20分以内の夕飯にしたい",
     );
     await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
@@ -202,7 +203,7 @@ describe("AiRecipeGenerator", () => {
     render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     await user.type(
-      screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
+      screen.getByPlaceholderText(/鶏むね肉、玉ねぎ、卵/),
       "鶏むね肉と卵で20分以内の夕飯にしたい",
     );
     await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
@@ -242,7 +243,7 @@ describe("AiRecipeGenerator", () => {
 
     render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
-    await user.type(screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/), "卵と米で作りたい");
+    await user.type(screen.getByPlaceholderText(/鶏むね肉、玉ねぎ、卵/), "卵と米で作りたい");
     await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
 
     await waitFor(() => {

--- a/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
+++ b/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
@@ -39,17 +39,40 @@ describe("AiRecipeGenerator", () => {
     expect(screen.getByText("AIで献立・レシピ提案")).toBeInTheDocument();
     expect(screen.getByText(/冷蔵庫にある食材や/)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/鶏むね肉、玉ねぎ、卵/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /レシピを提案/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /レシピを提案/ })).toBeDisabled();
   });
 
-  it("shows error and does not call API when prompt is empty", async () => {
-    const user = userEvent.setup();
+  it("does not call API when prompt is empty", async () => {
     render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
-    await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
-
-    expect(screen.getByText("希望や食材を入力してください")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /レシピを提案/ })).toBeDisabled();
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("submits with Enter", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: async () => ({
+        status: "success",
+        result: {
+          message: "この材料なら作れます。",
+          intent: "chat",
+          recipeDraft: null,
+          suggestions: ["もっと時短にする"],
+        },
+      }),
+    });
+
+    render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
+
+    await user.type(
+      screen.getByPlaceholderText(/鶏むね肉、玉ねぎ、卵/),
+      "鶏むね肉と卵で作りたい{Enter}",
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
   });
 
   it("shows chat message when API returns chat response", async () => {
@@ -61,6 +84,7 @@ describe("AiRecipeGenerator", () => {
           message: "この材料なら作れます。",
           intent: "chat",
           recipeDraft: null,
+          suggestions: ["もっと時短にする", "買い足しなしにする"],
         },
       }),
     });
@@ -76,6 +100,8 @@ describe("AiRecipeGenerator", () => {
     await waitFor(() => {
       expect(screen.getByText("この材料なら作れます。")).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: "もっと時短にする" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "買い足しなしにする" })).toBeInTheDocument();
     expect(screen.getByText("鶏むね肉と卵で20分以内の夕飯にしたい")).toBeInTheDocument();
     expect(global.fetch).toHaveBeenCalledWith(
       "/api/recipes/generate",
@@ -102,6 +128,7 @@ describe("AiRecipeGenerator", () => {
             steps: [{ instruction: "鶏むね肉を焼く", timerSeconds: null }],
             memo: "足りないもの: なし",
           },
+          suggestions: ["子供向けにする"],
         },
       }),
     });
@@ -136,6 +163,7 @@ describe("AiRecipeGenerator", () => {
             steps: [{ instruction: "鶏むね肉を焼く", timerSeconds: null }],
             memo: "足りないもの: なし",
           },
+          suggestions: ["保存前に調整する"],
         },
       }),
     });
@@ -186,6 +214,7 @@ describe("AiRecipeGenerator", () => {
               steps: [{ instruction: "鶏むね肉を焼く", timerSeconds: null }],
               memo: null,
             },
+            suggestions: ["もっと時短にして"],
           },
         }),
       })
@@ -196,6 +225,7 @@ describe("AiRecipeGenerator", () => {
             message: "さらに時短するなら、鶏むね肉を薄めに切ります。",
             intent: "chat",
             recipeDraft: null,
+            suggestions: ["買い足しなしで作る"],
           },
         }),
       });

--- a/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
+++ b/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
@@ -247,19 +247,15 @@ describe("AiRecipeGenerator", () => {
     await waitFor(() => {
       expect(screen.getByText(/さらに時短するなら/)).toBeInTheDocument();
     });
-    expect(global.fetch).toHaveBeenLastCalledWith(
-      "/api/recipes/generate",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({
-          messages: [
-            { role: "user", content: "鶏むね肉と卵で20分以内の夕飯にしたい" },
-            { role: "assistant", content: "レシピ下書きを作りました。" },
-            { role: "user", content: "もっと時短にして" },
-          ],
-        }),
-      }),
-    );
+    const lastCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    const requestInit = lastCall[1] as RequestInit;
+    const body = JSON.parse(requestInit.body as string);
+    expect(lastCall[0]).toBe("/api/recipes/generate");
+    expect(requestInit.method).toBe("POST");
+    expect(body.messages).toHaveLength(3);
+    expect(body.messages[1].content).toContain("レシピ下書き:");
+    expect(body.messages[1].content).toContain("タイトル: 鶏むね肉の卵とじ");
+    expect(body.messages[2]).toEqual({ role: "user", content: "もっと時短にして" });
   });
 
   it("shows error when API returns error", async () => {

--- a/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
+++ b/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AiRecipeGenerator } from "../ai-recipe-generator";
+
+global.fetch = vi.fn();
+
+describe("AiRecipeGenerator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the AI recipe generation form", () => {
+    render(<AiRecipeGenerator />);
+
+    expect(screen.getByText("AIで献立・レシピ提案")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /レシピを提案/ })).toBeInTheDocument();
+  });
+
+  it("shows error and does not call API when prompt is empty", async () => {
+    const user = userEvent.setup();
+    render(<AiRecipeGenerator />);
+
+    await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
+
+    expect(screen.getByText("希望や食材を入力してください")).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows generated markdown when API returns success", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: async () => ({
+        status: "success",
+        result: {
+          markdown: "この材料なら作れます。\n\n## レシピ名\n鶏むね肉の卵とじ",
+        },
+      }),
+    });
+
+    render(<AiRecipeGenerator />);
+
+    await user.type(
+      screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
+      "鶏むね肉と卵で20分以内の夕飯にしたい",
+    );
+    await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/鶏むね肉の卵とじ/)).toBeInTheDocument();
+    });
+    expect(screen.getByText("鶏むね肉と卵で20分以内の夕飯にしたい")).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/recipes/generate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "鶏むね肉と卵で20分以内の夕飯にしたい" }],
+        }),
+      }),
+    );
+  });
+
+  it("sends follow-up message with conversation history", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        json: async () => ({
+          status: "success",
+          result: {
+            markdown: "## レシピ名\n鶏むね肉の卵とじ",
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          status: "success",
+          result: {
+            markdown: "さらに時短するなら、鶏むね肉を薄めに切ります。",
+          },
+        }),
+      });
+
+    render(<AiRecipeGenerator />);
+
+    await user.type(
+      screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
+      "鶏むね肉と卵で20分以内の夕飯にしたい",
+    );
+    await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/鶏むね肉の卵とじ/)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "もっと時短にして" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/さらに時短するなら/)).toBeInTheDocument();
+    });
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      "/api/recipes/generate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          messages: [
+            { role: "user", content: "鶏むね肉と卵で20分以内の夕飯にしたい" },
+            { role: "assistant", content: "## レシピ名\n鶏むね肉の卵とじ" },
+            { role: "user", content: "もっと時短にして" },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("shows error when API returns error", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: async () => ({
+        status: "error",
+        error: "レシピ生成に失敗しました",
+      }),
+    });
+
+    render(<AiRecipeGenerator />);
+
+    await user.type(screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/), "卵と米で作りたい");
+    await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("レシピ生成に失敗しました")).toBeInTheDocument();
+    });
+  });
+});

--- a/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
+++ b/cook-scan/src/features/recipes/upload/__tests__/ai-recipe-generator.test.tsx
@@ -2,16 +2,39 @@ import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AiRecipeGenerator } from "../ai-recipe-generator";
+import type { CreateRecipeRequest } from "../types";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+const mockCreateRecipe = vi.fn();
+vi.mock("../actions", () => ({
+  createRecipe: (...args: [CreateRecipeRequest]) => mockCreateRecipe(...args),
+}));
 
 global.fetch = vi.fn();
 
 describe("AiRecipeGenerator", () => {
+  const mockTagCategories = [
+    {
+      id: "cat1",
+      name: "カテゴリ1",
+      description: null,
+      tags: [{ id: "tag1", name: "タグ1", description: null }],
+    },
+  ];
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCreateRecipe.mockResolvedValue({ ok: true, data: { recipeId: "recipe-1" } });
   });
 
   it("renders the AI recipe generation form", () => {
-    render(<AiRecipeGenerator />);
+    render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     expect(screen.getByText("AIで献立・レシピ提案")).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/)).toBeInTheDocument();
@@ -20,7 +43,7 @@ describe("AiRecipeGenerator", () => {
 
   it("shows error and does not call API when prompt is empty", async () => {
     const user = userEvent.setup();
-    render(<AiRecipeGenerator />);
+    render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
 
@@ -28,18 +51,20 @@ describe("AiRecipeGenerator", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("shows generated markdown when API returns success", async () => {
+  it("shows chat message when API returns chat response", async () => {
     const user = userEvent.setup();
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       json: async () => ({
         status: "success",
         result: {
-          markdown: "この材料なら作れます。\n\n## レシピ名\n鶏むね肉の卵とじ",
+          message: "この材料なら作れます。",
+          intent: "chat",
+          recipeDraft: null,
         },
       }),
     });
 
-    render(<AiRecipeGenerator />);
+    render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     await user.type(
       screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
@@ -48,7 +73,7 @@ describe("AiRecipeGenerator", () => {
     await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
 
     await waitFor(() => {
-      expect(screen.getByText(/鶏むね肉の卵とじ/)).toBeInTheDocument();
+      expect(screen.getByText("この材料なら作れます。")).toBeInTheDocument();
     });
     expect(screen.getByText("鶏むね肉と卵で20分以内の夕飯にしたい")).toBeInTheDocument();
     expect(global.fetch).toHaveBeenCalledWith(
@@ -62,27 +87,25 @@ describe("AiRecipeGenerator", () => {
     );
   });
 
-  it("sends follow-up message with conversation history", async () => {
+  it("shows recipe draft form when API returns recipe draft", async () => {
     const user = userEvent.setup();
-    (global.fetch as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({
-        json: async () => ({
-          status: "success",
-          result: {
-            markdown: "## レシピ名\n鶏むね肉の卵とじ",
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: async () => ({
+        status: "success",
+        result: {
+          message: "レシピ下書きを作りました。",
+          intent: "recipe_draft",
+          recipeDraft: {
+            title: "鶏むね肉の卵とじ",
+            ingredients: [{ name: "鶏むね肉", unit: "200g", notes: null }],
+            steps: [{ instruction: "鶏むね肉を焼く", timerSeconds: null }],
+            memo: "足りないもの: なし",
           },
-        }),
-      })
-      .mockResolvedValueOnce({
-        json: async () => ({
-          status: "success",
-          result: {
-            markdown: "さらに時短するなら、鶏むね肉を薄めに切ります。",
-          },
-        }),
-      });
+        },
+      }),
+    });
 
-    render(<AiRecipeGenerator />);
+    render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     await user.type(
       screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
@@ -91,7 +114,101 @@ describe("AiRecipeGenerator", () => {
     await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
 
     await waitFor(() => {
-      expect(screen.getByText(/鶏むね肉の卵とじ/)).toBeInTheDocument();
+      expect(screen.getByText("レシピ下書き")).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue("鶏むね肉の卵とじ")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("鶏むね肉")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("鶏むね肉を焼く")).toBeInTheDocument();
+  });
+
+  it("saves edited recipe draft", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: async () => ({
+        status: "success",
+        result: {
+          message: "レシピ下書きを作りました。",
+          intent: "recipe_draft",
+          recipeDraft: {
+            title: "鶏むね肉の卵とじ",
+            ingredients: [{ name: "鶏むね肉", unit: "200g", notes: null }],
+            steps: [{ instruction: "鶏むね肉を焼く", timerSeconds: null }],
+            memo: "足りないもの: なし",
+          },
+        },
+      }),
+    });
+
+    render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
+
+    await user.type(
+      screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
+      "鶏むね肉と卵で20分以内の夕飯にしたい",
+    );
+    await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("鶏むね肉の卵とじ")).toBeInTheDocument();
+    });
+
+    const titleInput = screen.getByLabelText(/レシピタイトル/);
+    await user.clear(titleInput);
+    await user.type(titleInput, "編集したレシピ");
+    await user.click(screen.getByRole("button", { name: /レシピを保存/ }));
+
+    await waitFor(() => {
+      expect(mockCreateRecipe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "編集したレシピ",
+          ingredients: [expect.objectContaining({ name: "鶏むね肉", unit: "200g" })],
+          steps: [expect.objectContaining({ instruction: "鶏むね肉を焼く" })],
+          tags: [],
+          childRecipes: [],
+        }),
+      );
+    });
+    expect(mockPush).toHaveBeenCalledWith("/recipes/recipe-1");
+  });
+
+  it("sends follow-up message with conversation history", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        json: async () => ({
+          status: "success",
+          result: {
+            message: "レシピ下書きを作りました。",
+            intent: "recipe_draft",
+            recipeDraft: {
+              title: "鶏むね肉の卵とじ",
+              ingredients: [{ name: "鶏むね肉", unit: "200g", notes: null }],
+              steps: [{ instruction: "鶏むね肉を焼く", timerSeconds: null }],
+              memo: null,
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          status: "success",
+          result: {
+            message: "さらに時短するなら、鶏むね肉を薄めに切ります。",
+            intent: "chat",
+            recipeDraft: null,
+          },
+        }),
+      });
+
+    render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
+
+    await user.type(
+      screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/),
+      "鶏むね肉と卵で20分以内の夕飯にしたい",
+    );
+    await user.click(screen.getByRole("button", { name: /レシピを提案/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("レシピ下書きを作りました。")).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("button", { name: "もっと時短にして" }));
@@ -106,7 +223,7 @@ describe("AiRecipeGenerator", () => {
         body: JSON.stringify({
           messages: [
             { role: "user", content: "鶏むね肉と卵で20分以内の夕飯にしたい" },
-            { role: "assistant", content: "## レシピ名\n鶏むね肉の卵とじ" },
+            { role: "assistant", content: "レシピ下書きを作りました。" },
             { role: "user", content: "もっと時短にして" },
           ],
         }),
@@ -123,7 +240,7 @@ describe("AiRecipeGenerator", () => {
       }),
     });
 
-    render(<AiRecipeGenerator />);
+    render(<AiRecipeGenerator tagCategories={mockTagCategories} />);
 
     await user.type(screen.getByPlaceholderText(/冷蔵庫に鶏むね肉/), "卵と米で作りたい");
     await user.click(screen.getByRole("button", { name: /レシピを提案/ }));

--- a/cook-scan/src/features/recipes/upload/__tests__/method-selector.test.tsx
+++ b/cook-scan/src/features/recipes/upload/__tests__/method-selector.test.tsx
@@ -13,6 +13,15 @@ describe("MethodSelector", () => {
     expect(screen.getByRole("button", { name: /画像からスキャン/ })).toBeInTheDocument();
   });
 
+  it("正常系：「AIで献立・レシピ提案」ボタンが表示される", () => {
+    // Given: MethodSelectorコンポーネントが表示されている
+    const onSelect = vi.fn();
+    render(<MethodSelector onSelect={onSelect} />);
+
+    // Then: 「AIで献立・レシピ提案」ボタンが表示される
+    expect(screen.getByRole("button", { name: /AIで献立・レシピ提案/ })).toBeInTheDocument();
+  });
+
   it("正常系：スキャンボタンをクリックするとonSelectが呼ばれる", async () => {
     // Given: MethodSelectorコンポーネントが表示されている
     const onSelect = vi.fn();
@@ -25,5 +34,19 @@ describe("MethodSelector", () => {
 
     // Then: onSelectが'scan'で呼ばれる
     expect(onSelect).toHaveBeenCalledWith("scan");
+  });
+
+  it("正常系：AI生成ボタンをクリックするとonSelectが呼ばれる", async () => {
+    // Given: MethodSelectorコンポーネントが表示されている
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<MethodSelector onSelect={onSelect} />);
+
+    // When: ユーザーが「AIで献立・レシピ提案」ボタンをクリックする
+    const aiGenerateButton = screen.getByRole("button", { name: /AIで献立・レシピ提案/ });
+    await user.click(aiGenerateButton);
+
+    // Then: onSelectが'ai-generate'で呼ばれる
+    expect(onSelect).toHaveBeenCalledWith("ai-generate");
   });
 });

--- a/cook-scan/src/features/recipes/upload/__tests__/recipe-upload-content.test.tsx
+++ b/cook-scan/src/features/recipes/upload/__tests__/recipe-upload-content.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/features/recipes/upload/method-selector", () => ({
       <button onClick={() => onSelect("scan")}>スキャン</button>
       <button onClick={() => onSelect("manual")}>手動入力</button>
       <button onClick={() => onSelect("text-input")}>テキスト入力</button>
+      <button onClick={() => onSelect("ai-generate")}>AI生成</button>
     </div>
   ),
 }));
@@ -64,6 +65,10 @@ vi.mock("@/features/recipes/upload/text-input", () => ({
       </button>
     </div>
   ),
+}));
+
+vi.mock("@/features/recipes/upload/ai-recipe-generator", () => ({
+  AiRecipeGenerator: () => <div data-testid="ai-recipe-generator">AIレシピ生成</div>,
 }));
 
 vi.mock("@/features/recipes/upload/recipe-form", () => ({
@@ -128,6 +133,16 @@ describe("RecipeUploadContent", () => {
     expect(screen.queryByTestId("method-selector")).not.toBeInTheDocument();
   });
 
+  it("navigates to AI recipe generator when ai-generate method is selected", async () => {
+    const user = userEvent.setup();
+    render(<RecipeUploadContent tagCategories={mockTagCategories} />);
+
+    await user.click(screen.getByText("AI生成"));
+
+    expect(screen.getByTestId("ai-recipe-generator")).toBeInTheDocument();
+    expect(screen.queryByTestId("method-selector")).not.toBeInTheDocument();
+  });
+
   it("navigates to form when manual method is selected", async () => {
     const user = userEvent.setup();
     render(<RecipeUploadContent tagCategories={mockTagCategories} />);
@@ -164,6 +179,17 @@ describe("RecipeUploadContent", () => {
 
     await user.click(screen.getByText("テキスト入力"));
     expect(screen.getByTestId("text-input")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /戻る/ }));
+    expect(screen.getByTestId("method-selector")).toBeInTheDocument();
+  });
+
+  it("navigates back to method selection from AI recipe generator", async () => {
+    const user = userEvent.setup();
+    render(<RecipeUploadContent tagCategories={mockTagCategories} />);
+
+    await user.click(screen.getByText("AI生成"));
+    expect(screen.getByTestId("ai-recipe-generator")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /戻る/ }));
     expect(screen.getByTestId("method-selector")).toBeInTheDocument();

--- a/cook-scan/src/features/recipes/upload/ai-recipe-draft-form.tsx
+++ b/cook-scan/src/features/recipes/upload/ai-recipe-draft-form.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { RecipeFormTagCategory } from "@/features/recipes/types/tag";
+import { createRecipe } from "./actions";
+import { isSuccess } from "@/utils/result";
+import { useRecipeForm } from "@/features/recipes/hooks/use-recipe-form";
+import { Alert } from "@/components/ui/alert";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  BasicInfoSection,
+  ChildRecipeSection,
+  FormActions,
+  IngredientSection,
+  StepSection,
+  TagSection,
+} from "@/features/recipes/components";
+
+export type AiRecipeDraft = {
+  title: string;
+  ingredients: Array<{
+    name: string;
+    unit: string;
+    notes: string | null;
+  }>;
+  steps: Array<{
+    instruction: string;
+    timerSeconds: number | null;
+  }>;
+  memo: string | null;
+};
+
+type Props = {
+  draft: AiRecipeDraft;
+  tagCategories: RecipeFormTagCategory[];
+  onCancel: () => void;
+};
+
+export function AiRecipeDraftForm({ draft, tagCategories, onCancel }: Props) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isChildRecipeDialogOpen, setIsChildRecipeDialogOpen] = useState(false);
+
+  const {
+    title,
+    setTitle,
+    sourceInfo,
+    setSourceInfo,
+    ingredients,
+    steps,
+    memo,
+    setMemo,
+    selectedTagIds,
+    childRecipes,
+    addIngredient,
+    removeIngredient,
+    updateIngredient,
+    addStep,
+    removeStep,
+    updateStep,
+    addChildRecipe,
+    removeChildRecipe,
+    updateChildRecipe,
+    toggleTag,
+  } = useRecipeForm({
+    initialData: {
+      title: draft.title,
+      sourceInfo: {
+        bookName: "",
+        pageNumber: "",
+        url: "",
+      },
+      ingredients: draft.ingredients.map((ingredient) => ({
+        name: ingredient.name,
+        unit: ingredient.unit,
+        notes: ingredient.notes ?? "",
+      })),
+      steps: draft.steps.map((step, index) => ({
+        instruction: step.instruction,
+        timerSeconds: step.timerSeconds ?? undefined,
+        orderIndex: index + 1,
+      })),
+      memo: draft.memo ?? "",
+      selectedTagIds: [],
+      childRecipes: [],
+    },
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const result = await createRecipe({
+        title,
+        sourceInfo:
+          sourceInfo.bookName || sourceInfo.pageNumber || sourceInfo.url ? sourceInfo : null,
+        ingredients,
+        steps,
+        memo,
+        tags: selectedTagIds,
+        childRecipes: childRecipes.map((cr) => ({
+          childRecipeId: cr.childRecipeId,
+          quantity: cr.quantity || undefined,
+          notes: cr.notes || undefined,
+        })),
+      });
+
+      if (isSuccess(result)) {
+        router.push(`/recipes/${result.data.recipeId}`);
+      } else {
+        setError(result.error.message);
+        setIsSubmitting(false);
+      }
+    } catch (err) {
+      console.error("Error creating AI recipe draft:", err);
+      setError("エラーが発生しました");
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {error && <Alert variant="error">{error}</Alert>}
+
+      <BasicInfoSection
+        title={title}
+        onTitleChange={setTitle}
+        sourceInfo={sourceInfo}
+        onSourceInfoChange={setSourceInfo}
+        memo={memo}
+        onMemoChange={setMemo}
+      />
+
+      <TagSection
+        tagCategories={tagCategories}
+        selectedTagIds={selectedTagIds}
+        onToggleTag={toggleTag}
+      />
+
+      <IngredientSection
+        ingredients={ingredients}
+        onAdd={addIngredient}
+        onUpdate={updateIngredient}
+        onRemove={removeIngredient}
+      />
+
+      <ChildRecipeSection
+        childRecipes={childRecipes}
+        isDialogOpen={isChildRecipeDialogOpen}
+        onOpenDialog={() => setIsChildRecipeDialogOpen(true)}
+        onCloseDialog={() => setIsChildRecipeDialogOpen(false)}
+        onAdd={addChildRecipe}
+        onUpdate={updateChildRecipe}
+        onRemove={removeChildRecipe}
+      />
+
+      <StepSection steps={steps} onAdd={addStep} onUpdate={updateStep} onRemove={removeStep} />
+
+      <Card>
+        <CardContent>
+          <FormActions
+            isSubmitting={isSubmitting}
+            disabled={!title}
+            submitLabel="レシピを保存"
+            onCancel={onCancel}
+          />
+        </CardContent>
+      </Card>
+    </form>
+  );
+}

--- a/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
+++ b/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
@@ -31,6 +31,7 @@ const initialAssistantMessage =
 type ChatMessage = {
   role: "user" | "assistant";
   content: string;
+  context?: string;
 };
 
 type Props = {
@@ -51,6 +52,37 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
     if (error) setError(null);
   };
 
+  const formatRecipeDraftForContext = (draft: AiRecipeDraft) => {
+    const ingredients = draft.ingredients
+      .map((ingredient) => {
+        const notes = ingredient.notes ? ` (${ingredient.notes})` : "";
+        return `- ${ingredient.name}: ${ingredient.unit}${notes}`;
+      })
+      .join("\n");
+    const steps = draft.steps
+      .map((step, index) => {
+        const timer = step.timerSeconds ? ` (${step.timerSeconds}秒)` : "";
+        return `${index + 1}. ${step.instruction}${timer}`;
+      })
+      .join("\n");
+
+    return [
+      "レシピ下書き:",
+      `タイトル: ${draft.title}`,
+      "材料:",
+      ingredients,
+      "手順:",
+      steps,
+      `メモ: ${draft.memo ?? "なし"}`,
+    ].join("\n");
+  };
+
+  const buildRequestMessages = (nextMessages: ChatMessage[]) =>
+    nextMessages.map((message) => ({
+      role: message.role,
+      content: message.context ? `${message.content}\n\n${message.context}` : message.content,
+    }));
+
   const sendMessage = async (content: string) => {
     const trimmedPrompt = content.trim();
 
@@ -68,6 +100,7 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
 
     setError(null);
     setIsLoading(true);
+    setSuggestions([]);
     setMessages(nextMessages);
     setPrompt("");
 
@@ -77,7 +110,7 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ messages: nextMessages }),
+        body: JSON.stringify({ messages: buildRequestMessages(nextMessages) }),
       });
       const data: GenerateRecipeResponse = await response.json().catch(() => ({
         status: "error" as const,
@@ -85,9 +118,13 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
       }));
 
       if (data.status === "success") {
+        const draftContext =
+          data.result.intent === "recipe_draft" && data.result.recipeDraft
+            ? formatRecipeDraftForContext(data.result.recipeDraft)
+            : undefined;
         setMessages((currentMessages) => [
           ...currentMessages,
-          { role: "assistant", content: data.result.message },
+          { role: "assistant", content: data.result.message, context: draftContext },
         ]);
         setSuggestions(data.result.suggestions);
         if (data.result.intent === "recipe_draft" && data.result.recipeDraft) {

--- a/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
+++ b/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
@@ -16,6 +16,7 @@ type GenerateRecipeResponse =
         message: string;
         intent: "chat" | "recipe_draft";
         recipeDraft: AiRecipeDraft | null;
+        suggestions: string[];
       };
     }
   | {
@@ -24,7 +25,6 @@ type GenerateRecipeResponse =
     };
 
 const minChars = 5;
-const suggestionPrompts = ["もっと時短にして", "買い足しなしで作りたい", "子供向けにして"];
 const initialAssistantMessage =
   "冷蔵庫にある食材や、作りたい雰囲気を教えてください。条件があれば一緒に書くと、レシピの下書きまで作れます。";
 
@@ -40,6 +40,7 @@ type Props = {
 export function AiRecipeGenerator({ tagCategories }: Props) {
   const [prompt, setPrompt] = useState("");
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
   const [recipeDraft, setRecipeDraft] = useState<AiRecipeDraft | null>(null);
   const [recipeDraftVersion, setRecipeDraftVersion] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -88,6 +89,7 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
           ...currentMessages,
           { role: "assistant", content: data.result.message },
         ]);
+        setSuggestions(data.result.suggestions);
         if (data.result.intent === "recipe_draft" && data.result.recipeDraft) {
           setRecipeDraft(data.result.recipeDraft);
           setRecipeDraftVersion((currentVersion) => currentVersion + 1);
@@ -107,7 +109,17 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
     await sendMessage(prompt);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      if (!isLoading && prompt.trim()) {
+        void sendMessage(prompt);
+      }
+    }
+  };
+
   const hasRecipeDraft = recipeDraft !== null;
+  const canSubmit = !isLoading && prompt.trim().length > 0;
 
   return (
     <div
@@ -162,9 +174,9 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
 
             {error && <Alert variant="error">{error}</Alert>}
 
-            {messages.some((message) => message.role === "assistant") && (
+            {suggestions.length > 0 && (
               <div className="flex flex-wrap gap-2">
-                {suggestionPrompts.map((suggestion) => (
+                {suggestions.map((suggestion) => (
                   <Button
                     key={suggestion}
                     type="button"
@@ -183,6 +195,7 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
               <Textarea
                 value={prompt}
                 onChange={handleChange}
+                onKeyDown={handleKeyDown}
                 placeholder="例：鶏むね肉、玉ねぎ、卵があります。20分くらいで作れる夕飯にしたいです。"
                 rows={2}
                 className="min-h-[64px] flex-1 resize-none"
@@ -190,7 +203,7 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
               />
               <Button
                 onClick={handleSubmit}
-                disabled={isLoading}
+                disabled={!canSubmit}
                 isLoading={isLoading}
                 size="lg"
                 className="self-end"
@@ -204,7 +217,7 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
       </div>
 
       {recipeDraft && (
-        <div>
+        <div className="max-h-[calc(100vh-160px)] overflow-y-auto pr-1">
           <div className="mb-6">
             <h2 className="text-foreground text-xl font-bold">レシピ下書き</h2>
             <p className="text-muted-foreground mt-2 text-sm leading-relaxed">

--- a/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
+++ b/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { DocumentTextIcon } from "@/components/icons/document-text-icon";
+import { LightningBoltIcon } from "@/components/icons/lightning-bolt-icon";
+
+type GenerateRecipeResponse =
+  | {
+      status: "success";
+      result: {
+        markdown: string;
+      };
+    }
+  | {
+      status: "error";
+      error: string;
+    };
+
+const minChars = 5;
+const suggestionPrompts = ["もっと時短にして", "買い足しなしで作りたい", "子供向けにして"];
+
+type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+export function AiRecipeGenerator() {
+  const [prompt, setPrompt] = useState("");
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setPrompt(e.target.value);
+    if (error) setError(null);
+  };
+
+  const sendMessage = async (content: string) => {
+    const trimmedPrompt = content.trim();
+
+    if (!trimmedPrompt) {
+      setError("希望や食材を入力してください");
+      return;
+    }
+
+    if (trimmedPrompt.length < minChars) {
+      setError(`${minChars}文字以上入力してください`);
+      return;
+    }
+
+    const nextMessages: ChatMessage[] = [...messages, { role: "user", content: trimmedPrompt }];
+
+    setError(null);
+    setIsLoading(true);
+    setMessages(nextMessages);
+    setPrompt("");
+
+    try {
+      const response = await fetch("/api/recipes/generate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ messages: nextMessages }),
+      });
+      const data: GenerateRecipeResponse = await response.json().catch(() => ({
+        status: "error" as const,
+        error: "レシピ生成に失敗しました",
+      }));
+
+      if (data.status === "success") {
+        setMessages((currentMessages) => [
+          ...currentMessages,
+          { role: "assistant", content: data.result.markdown },
+        ]);
+      } else {
+        setError(data.error);
+      }
+    } catch (e) {
+      console.error(e);
+      setError("レシピ生成に失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    await sendMessage(prompt);
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-6 text-center">
+        <div className="mb-3 flex items-center justify-center gap-2">
+          <div className="from-accent-ingredients to-accent-steps flex h-10 w-10 items-center justify-center rounded-lg bg-linear-to-br shadow-md">
+            <LightningBoltIcon className="h-5 w-5 text-white" />
+          </div>
+          <h2 className="text-foreground text-xl font-bold">AIで献立・レシピ提案</h2>
+        </div>
+        <p className="text-muted-foreground text-sm leading-relaxed">
+          最初に食材や希望を入力し、そのあと追加の要望でレシピを調整できます
+        </p>
+      </div>
+
+      <div className="ring-card-border overflow-hidden rounded-xl bg-white shadow-lg ring-1">
+        <div className="border-border from-section-header border-b bg-linear-to-r to-white px-6 py-4">
+          <div className="flex items-center gap-2">
+            <div className="from-accent-ingredients to-accent-steps flex h-8 w-8 items-center justify-center rounded-lg bg-linear-to-br">
+              <DocumentTextIcon className="h-4 w-4 text-white" />
+            </div>
+            <span className="text-foreground text-sm font-semibold">AIレシピチャット</span>
+          </div>
+        </div>
+
+        <div className="space-y-4 p-6">
+          {messages.length > 0 && (
+            <div className="border-border bg-muted/20 max-h-[520px] space-y-4 overflow-y-auto rounded-lg border p-4">
+              {messages.map((message, index) => (
+                <div
+                  key={`${message.role}-${index}`}
+                  className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
+                >
+                  <div
+                    className={`max-w-[85%] rounded-xl px-4 py-3 text-sm leading-7 whitespace-pre-wrap ${
+                      message.role === "user"
+                        ? "bg-primary text-primary-foreground"
+                        : "text-foreground ring-border bg-white shadow-sm ring-1"
+                    }`}
+                  >
+                    {message.content}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <Textarea
+            value={prompt}
+            onChange={handleChange}
+            placeholder={
+              messages.length === 0
+                ? "例：冷蔵庫に鶏むね肉、玉ねぎ、卵があります。20分くらいで作れる夕飯にしたいです。辛いものは避けたいです。"
+                : "例：もっと時短にして / 買い足しなしで作りたい / 子供向けにして"
+            }
+            rows={messages.length === 0 ? 8 : 4}
+            className={messages.length === 0 ? "min-h-[220px] resize-y" : "min-h-[120px] resize-y"}
+            disabled={isLoading}
+          />
+
+          {error && <Alert variant="error">{error}</Alert>}
+
+          {messages.some((message) => message.role === "assistant") && (
+            <div className="flex flex-wrap gap-2">
+              {suggestionPrompts.map((suggestion) => (
+                <Button
+                  key={suggestion}
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  disabled={isLoading}
+                  onClick={() => sendMessage(suggestion)}
+                >
+                  {suggestion}
+                </Button>
+              ))}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <Button onClick={handleSubmit} disabled={isLoading} isLoading={isLoading} size="lg">
+              {!isLoading && <LightningBoltIcon className="h-5 w-5" />}
+              {isLoading ? "考え中..." : messages.length === 0 ? "レシピを提案" : "送信"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
+++ b/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import type { RecipeFormTagCategory } from "@/features/recipes/types/tag";
+import { AiRecipeDraftForm, type AiRecipeDraft } from "./ai-recipe-draft-form";
 import { DocumentTextIcon } from "@/components/icons/document-text-icon";
 import { LightningBoltIcon } from "@/components/icons/lightning-bolt-icon";
 
@@ -11,7 +13,9 @@ type GenerateRecipeResponse =
   | {
       status: "success";
       result: {
-        markdown: string;
+        message: string;
+        intent: "chat" | "recipe_draft";
+        recipeDraft: AiRecipeDraft | null;
       };
     }
   | {
@@ -27,9 +31,15 @@ type ChatMessage = {
   content: string;
 };
 
-export function AiRecipeGenerator() {
+type Props = {
+  tagCategories: RecipeFormTagCategory[];
+};
+
+export function AiRecipeGenerator({ tagCategories }: Props) {
   const [prompt, setPrompt] = useState("");
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [recipeDraft, setRecipeDraft] = useState<AiRecipeDraft | null>(null);
+  const [recipeDraftVersion, setRecipeDraftVersion] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -74,8 +84,12 @@ export function AiRecipeGenerator() {
       if (data.status === "success") {
         setMessages((currentMessages) => [
           ...currentMessages,
-          { role: "assistant", content: data.result.markdown },
+          { role: "assistant", content: data.result.message },
         ]);
+        if (data.result.intent === "recipe_draft" && data.result.recipeDraft) {
+          setRecipeDraft(data.result.recipeDraft);
+          setRecipeDraftVersion((currentVersion) => currentVersion + 1);
+        }
       } else {
         setError(data.error);
       }
@@ -91,92 +105,121 @@ export function AiRecipeGenerator() {
     await sendMessage(prompt);
   };
 
+  const hasRecipeDraft = recipeDraft !== null;
+
   return (
-    <div className="mx-auto max-w-3xl">
-      <div className="mb-6 text-center">
-        <div className="mb-3 flex items-center justify-center gap-2">
-          <div className="from-accent-ingredients to-accent-steps flex h-10 w-10 items-center justify-center rounded-lg bg-linear-to-br shadow-md">
-            <LightningBoltIcon className="h-5 w-5 text-white" />
-          </div>
-          <h2 className="text-foreground text-xl font-bold">AIで献立・レシピ提案</h2>
-        </div>
-        <p className="text-muted-foreground text-sm leading-relaxed">
-          最初に食材や希望を入力し、そのあと追加の要望でレシピを調整できます
-        </p>
-      </div>
-
-      <div className="ring-card-border overflow-hidden rounded-xl bg-white shadow-lg ring-1">
-        <div className="border-border from-section-header border-b bg-linear-to-r to-white px-6 py-4">
-          <div className="flex items-center gap-2">
-            <div className="from-accent-ingredients to-accent-steps flex h-8 w-8 items-center justify-center rounded-lg bg-linear-to-br">
-              <DocumentTextIcon className="h-4 w-4 text-white" />
+    <div
+      className={
+        hasRecipeDraft
+          ? "mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(420px,1.1fr)]"
+          : "mx-auto max-w-3xl"
+      }
+    >
+      <div>
+        <div className="mb-6 text-center">
+          <div className="mb-3 flex items-center justify-center gap-2">
+            <div className="from-accent-ingredients to-accent-steps flex h-10 w-10 items-center justify-center rounded-lg bg-linear-to-br shadow-md">
+              <LightningBoltIcon className="h-5 w-5 text-white" />
             </div>
-            <span className="text-foreground text-sm font-semibold">AIレシピチャット</span>
+            <h2 className="text-foreground text-xl font-bold">AIで献立・レシピ提案</h2>
           </div>
+          <p className="text-muted-foreground text-sm leading-relaxed">
+            最初に食材や希望を入力し、そのあと追加の要望でレシピを調整できます
+          </p>
         </div>
 
-        <div className="space-y-4 p-6">
-          {messages.length > 0 && (
-            <div className="border-border bg-muted/20 max-h-[520px] space-y-4 overflow-y-auto rounded-lg border p-4">
-              {messages.map((message, index) => (
-                <div
-                  key={`${message.role}-${index}`}
-                  className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
-                >
+        <div className="ring-card-border overflow-hidden rounded-xl bg-white shadow-lg ring-1">
+          <div className="border-border from-section-header border-b bg-linear-to-r to-white px-6 py-4">
+            <div className="flex items-center gap-2">
+              <div className="from-accent-ingredients to-accent-steps flex h-8 w-8 items-center justify-center rounded-lg bg-linear-to-br">
+                <DocumentTextIcon className="h-4 w-4 text-white" />
+              </div>
+              <span className="text-foreground text-sm font-semibold">AIレシピチャット</span>
+            </div>
+          </div>
+
+          <div className="space-y-4 p-6">
+            {messages.length > 0 && (
+              <div className="border-border bg-muted/20 max-h-[520px] space-y-4 overflow-y-auto rounded-lg border p-4">
+                {messages.map((message, index) => (
                   <div
-                    className={`max-w-[85%] rounded-xl px-4 py-3 text-sm leading-7 whitespace-pre-wrap ${
-                      message.role === "user"
-                        ? "bg-primary text-primary-foreground"
-                        : "text-foreground ring-border bg-white shadow-sm ring-1"
-                    }`}
+                    key={`${message.role}-${index}`}
+                    className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
                   >
-                    {message.content}
+                    <div
+                      className={`max-w-[85%] rounded-xl px-4 py-3 text-sm leading-7 whitespace-pre-wrap ${
+                        message.role === "user"
+                          ? "bg-primary text-primary-foreground"
+                          : "text-foreground ring-border bg-white shadow-sm ring-1"
+                      }`}
+                    >
+                      {message.content}
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))}
+              </div>
+            )}
+
+            <Textarea
+              value={prompt}
+              onChange={handleChange}
+              placeholder={
+                messages.length === 0
+                  ? "例：冷蔵庫に鶏むね肉、玉ねぎ、卵があります。20分くらいで作れる夕飯にしたいです。辛いものは避けたいです。"
+                  : "例：もっと時短にして / 買い足しなしで作りたい / 子供向けにして"
+              }
+              rows={messages.length === 0 ? 8 : 4}
+              className={
+                messages.length === 0 ? "min-h-[220px] resize-y" : "min-h-[120px] resize-y"
+              }
+              disabled={isLoading}
+            />
+
+            {error && <Alert variant="error">{error}</Alert>}
+
+            {messages.some((message) => message.role === "assistant") && (
+              <div className="flex flex-wrap gap-2">
+                {suggestionPrompts.map((suggestion) => (
+                  <Button
+                    key={suggestion}
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    disabled={isLoading}
+                    onClick={() => sendMessage(suggestion)}
+                  >
+                    {suggestion}
+                  </Button>
+                ))}
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <Button onClick={handleSubmit} disabled={isLoading} isLoading={isLoading} size="lg">
+                {!isLoading && <LightningBoltIcon className="h-5 w-5" />}
+                {isLoading ? "考え中..." : messages.length === 0 ? "レシピを提案" : "送信"}
+              </Button>
             </div>
-          )}
-
-          <Textarea
-            value={prompt}
-            onChange={handleChange}
-            placeholder={
-              messages.length === 0
-                ? "例：冷蔵庫に鶏むね肉、玉ねぎ、卵があります。20分くらいで作れる夕飯にしたいです。辛いものは避けたいです。"
-                : "例：もっと時短にして / 買い足しなしで作りたい / 子供向けにして"
-            }
-            rows={messages.length === 0 ? 8 : 4}
-            className={messages.length === 0 ? "min-h-[220px] resize-y" : "min-h-[120px] resize-y"}
-            disabled={isLoading}
-          />
-
-          {error && <Alert variant="error">{error}</Alert>}
-
-          {messages.some((message) => message.role === "assistant") && (
-            <div className="flex flex-wrap gap-2">
-              {suggestionPrompts.map((suggestion) => (
-                <Button
-                  key={suggestion}
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  disabled={isLoading}
-                  onClick={() => sendMessage(suggestion)}
-                >
-                  {suggestion}
-                </Button>
-              ))}
-            </div>
-          )}
-
-          <div className="flex justify-end">
-            <Button onClick={handleSubmit} disabled={isLoading} isLoading={isLoading} size="lg">
-              {!isLoading && <LightningBoltIcon className="h-5 w-5" />}
-              {isLoading ? "考え中..." : messages.length === 0 ? "レシピを提案" : "送信"}
-            </Button>
           </div>
         </div>
       </div>
+
+      {recipeDraft && (
+        <div>
+          <div className="mb-6">
+            <h2 className="text-foreground text-xl font-bold">レシピ下書き</h2>
+            <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+              AIが作成した下書きを確認・編集してから保存できます
+            </p>
+          </div>
+          <AiRecipeDraftForm
+            key={recipeDraftVersion}
+            draft={recipeDraft}
+            tagCategories={tagCategories}
+            onCancel={() => setRecipeDraft(null)}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
+++ b/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
@@ -114,34 +114,29 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
       className={
         hasRecipeDraft
           ? "mx-auto grid max-w-7xl gap-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(420px,1.1fr)]"
-          : "mx-auto max-w-3xl"
+          : "mx-auto max-w-5xl"
       }
     >
       <div>
-        <div className="mb-6">
-          <div className="mb-3 flex items-center gap-2">
-            <div className="from-accent-ingredients to-accent-steps flex h-10 w-10 items-center justify-center rounded-lg bg-linear-to-br shadow-md">
-              <LightningBoltIcon className="h-5 w-5 text-white" />
-            </div>
-            <h2 className="text-foreground text-xl font-bold">AIで献立・レシピ提案</h2>
-          </div>
-          <p className="text-muted-foreground text-sm leading-relaxed">
-            最初に食材や希望を入力し、そのあと追加の要望でレシピを調整できます
-          </p>
-        </div>
-
-        <div className="ring-card-border overflow-hidden rounded-xl bg-white shadow-lg ring-1">
+        <div className="ring-card-border flex min-h-[calc(100vh-220px)] flex-col overflow-hidden rounded-xl bg-white shadow-lg ring-1">
           <div className="border-border from-section-header border-b bg-linear-to-r to-white px-6 py-4">
-            <div className="flex items-center gap-2">
-              <div className="from-accent-ingredients to-accent-steps flex h-8 w-8 items-center justify-center rounded-lg bg-linear-to-br">
-                <DocumentTextIcon className="h-4 w-4 text-white" />
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className="from-accent-ingredients to-accent-steps flex h-9 w-9 items-center justify-center rounded-lg bg-linear-to-br">
+                  <DocumentTextIcon className="h-4 w-4 text-white" />
+                </div>
+                <div>
+                  <h2 className="text-foreground text-base font-bold">AIで献立・レシピ提案</h2>
+                  <p className="text-muted-foreground mt-0.5 text-xs">
+                    食材や希望を送ると、会話しながらレシピ下書きまで作れます
+                  </p>
+                </div>
               </div>
-              <span className="text-foreground text-sm font-semibold">AIレシピチャット</span>
             </div>
           </div>
 
-          <div className="space-y-4 p-6">
-            <div className="border-border bg-muted/20 max-h-[520px] min-h-[260px] space-y-4 overflow-y-auto rounded-lg border p-4">
+          <div className="flex flex-1 flex-col gap-4 p-6">
+            <div className="border-border bg-muted/20 min-h-[320px] flex-1 space-y-4 overflow-y-auto rounded-lg border p-4">
               <div className="flex justify-start">
                 <div className="text-foreground ring-border max-w-[85%] rounded-xl bg-white px-4 py-3 text-sm leading-7 whitespace-pre-wrap shadow-sm ring-1">
                   {initialAssistantMessage}
@@ -165,15 +160,6 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
               ))}
             </div>
 
-            <Textarea
-              value={prompt}
-              onChange={handleChange}
-              placeholder="例：鶏むね肉、玉ねぎ、卵があります。20分くらいで作れる夕飯にしたいです。"
-              rows={3}
-              className="min-h-[96px] resize-y"
-              disabled={isLoading}
-            />
-
             {error && <Alert variant="error">{error}</Alert>}
 
             {messages.some((message) => message.role === "assistant") && (
@@ -193,8 +179,22 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
               </div>
             )}
 
-            <div className="flex justify-end">
-              <Button onClick={handleSubmit} disabled={isLoading} isLoading={isLoading} size="lg">
+            <div className="flex gap-3">
+              <Textarea
+                value={prompt}
+                onChange={handleChange}
+                placeholder="例：鶏むね肉、玉ねぎ、卵があります。20分くらいで作れる夕飯にしたいです。"
+                rows={2}
+                className="min-h-[64px] flex-1 resize-none"
+                disabled={isLoading}
+              />
+              <Button
+                onClick={handleSubmit}
+                disabled={isLoading}
+                isLoading={isLoading}
+                size="lg"
+                className="self-end"
+              >
                 {!isLoading && <LightningBoltIcon className="h-5 w-5" />}
                 {isLoading ? "考え中..." : messages.length === 0 ? "レシピを提案" : "送信"}
               </Button>

--- a/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
+++ b/cook-scan/src/features/recipes/upload/ai-recipe-generator.tsx
@@ -25,6 +25,8 @@ type GenerateRecipeResponse =
 
 const minChars = 5;
 const suggestionPrompts = ["もっと時短にして", "買い足しなしで作りたい", "子供向けにして"];
+const initialAssistantMessage =
+  "冷蔵庫にある食材や、作りたい雰囲気を教えてください。条件があれば一緒に書くと、レシピの下書きまで作れます。";
 
 type ChatMessage = {
   role: "user" | "assistant";
@@ -116,8 +118,8 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
       }
     >
       <div>
-        <div className="mb-6 text-center">
-          <div className="mb-3 flex items-center justify-center gap-2">
+        <div className="mb-6">
+          <div className="mb-3 flex items-center gap-2">
             <div className="from-accent-ingredients to-accent-steps flex h-10 w-10 items-center justify-center rounded-lg bg-linear-to-br shadow-md">
               <LightningBoltIcon className="h-5 w-5 text-white" />
             </div>
@@ -139,39 +141,36 @@ export function AiRecipeGenerator({ tagCategories }: Props) {
           </div>
 
           <div className="space-y-4 p-6">
-            {messages.length > 0 && (
-              <div className="border-border bg-muted/20 max-h-[520px] space-y-4 overflow-y-auto rounded-lg border p-4">
-                {messages.map((message, index) => (
-                  <div
-                    key={`${message.role}-${index}`}
-                    className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
-                  >
-                    <div
-                      className={`max-w-[85%] rounded-xl px-4 py-3 text-sm leading-7 whitespace-pre-wrap ${
-                        message.role === "user"
-                          ? "bg-primary text-primary-foreground"
-                          : "text-foreground ring-border bg-white shadow-sm ring-1"
-                      }`}
-                    >
-                      {message.content}
-                    </div>
-                  </div>
-                ))}
+            <div className="border-border bg-muted/20 max-h-[520px] min-h-[260px] space-y-4 overflow-y-auto rounded-lg border p-4">
+              <div className="flex justify-start">
+                <div className="text-foreground ring-border max-w-[85%] rounded-xl bg-white px-4 py-3 text-sm leading-7 whitespace-pre-wrap shadow-sm ring-1">
+                  {initialAssistantMessage}
+                </div>
               </div>
-            )}
+              {messages.map((message, index) => (
+                <div
+                  key={`${message.role}-${index}`}
+                  className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
+                >
+                  <div
+                    className={`max-w-[85%] rounded-xl px-4 py-3 text-sm leading-7 whitespace-pre-wrap ${
+                      message.role === "user"
+                        ? "bg-primary text-primary-foreground"
+                        : "text-foreground ring-border bg-white shadow-sm ring-1"
+                    }`}
+                  >
+                    {message.content}
+                  </div>
+                </div>
+              ))}
+            </div>
 
             <Textarea
               value={prompt}
               onChange={handleChange}
-              placeholder={
-                messages.length === 0
-                  ? "例：冷蔵庫に鶏むね肉、玉ねぎ、卵があります。20分くらいで作れる夕飯にしたいです。辛いものは避けたいです。"
-                  : "例：もっと時短にして / 買い足しなしで作りたい / 子供向けにして"
-              }
-              rows={messages.length === 0 ? 8 : 4}
-              className={
-                messages.length === 0 ? "min-h-[220px] resize-y" : "min-h-[120px] resize-y"
-              }
+              placeholder="例：鶏むね肉、玉ねぎ、卵があります。20分くらいで作れる夕飯にしたいです。"
+              rows={3}
+              className="min-h-[96px] resize-y"
               disabled={isLoading}
             />
 

--- a/cook-scan/src/features/recipes/upload/method-selector.tsx
+++ b/cook-scan/src/features/recipes/upload/method-selector.tsx
@@ -3,9 +3,10 @@ import { CheckSolidIcon } from "@/components/icons/check-solid-icon";
 import { AdjustmentsIcon } from "@/components/icons/adjustments-icon";
 import { DocumentTextIcon } from "@/components/icons/document-text-icon";
 import { CheckCircleOutlineIcon } from "@/components/icons/check-circle-outline-icon";
+import { LightningBoltIcon } from "@/components/icons/lightning-bolt-icon";
 
 type Props = {
-  onSelect: (method: "scan" | "manual" | "text-input") => void;
+  onSelect: (method: "scan" | "manual" | "text-input" | "ai-generate") => void;
 };
 
 export default function MethodSelector({ onSelect }: Props) {
@@ -77,6 +78,28 @@ export default function MethodSelector({ onSelect }: Props) {
           <div className="text-foreground mt-4 inline-flex items-center gap-1 text-sm font-medium">
             <CheckCircleOutlineIcon className="h-4 w-4" />
             詳細な編集が可能
+          </div>
+        </div>
+      </button>
+
+      <button
+        onClick={() => onSelect("ai-generate")}
+        className="group ring-card-border relative overflow-hidden rounded-xl bg-white p-8 text-left shadow-lg ring-1 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+      >
+        <div className="from-accent-ingredients-light to-accent-steps-light absolute top-0 right-0 h-32 w-32 translate-x-8 -translate-y-8 rounded-full bg-linear-to-br opacity-50 transition-transform group-hover:scale-110" />
+        <div className="relative flex flex-col items-center text-center">
+          <div className="from-accent-ingredients to-accent-steps rounded-xl bg-linear-to-br p-4 shadow-lg transition-transform group-hover:scale-110">
+            <LightningBoltIcon className="h-12 w-12 text-white" />
+          </div>
+          <h3 className="text-foreground mt-4 text-xl font-bold">AIで献立・レシピ提案</h3>
+          <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+            手持ちの食材や希望を入力して、AIが作りやすいレシピを提案します
+          </p>
+          <div className="mt-4 flex items-center gap-2">
+            <span className="bg-accent-ingredients-light text-accent-ingredients ring-accent-ingredients inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold ring-1">
+              <LightningBoltIcon className="h-3.5 w-3.5" />
+              AI提案
+            </span>
           </div>
         </div>
       </button>

--- a/cook-scan/src/features/recipes/upload/recipe-upload-content.tsx
+++ b/cook-scan/src/features/recipes/upload/recipe-upload-content.tsx
@@ -4,13 +4,15 @@ import { useState } from "react";
 import MethodSelector from "@/features/recipes/upload/method-selector";
 import ImageUpload from "@/features/recipes/upload/image-upload";
 import RecipeForm from "@/features/recipes/upload/recipe-form";
+import { AiRecipeGenerator } from "@/features/recipes/upload/ai-recipe-generator";
 import type { ExtractedRecipeData } from "@/features/recipes/upload/types";
 import type { RecipeFormTagCategory } from "@/features/recipes/types/tag";
 import { Button } from "@/components/ui/button";
 import { TextInput } from "./text-input";
 import { ChevronLeftIcon } from "@/components/icons/chevron-left-icon";
 
-type Step = "method-selection" | "image-upload" | "text-input" | "form";
+type Step = "method-selection" | "image-upload" | "text-input" | "ai-generate" | "form";
+type RecipeUploadMethod = "scan" | "manual" | "text-input" | "ai-generate";
 
 type Props = {
   tagCategories: RecipeFormTagCategory[];
@@ -22,13 +24,14 @@ export default function RecipeUploadContent({ tagCategories }: Props) {
   const [extractedData, setExtractedData] = useState<ExtractedRecipeData | null>(null);
   const [isUploading, setIsUploading] = useState(false);
 
-  const stepMap: Record<string, Step> = {
+  const stepMap: Record<RecipeUploadMethod, Step> = {
     scan: "image-upload",
     "text-input": "text-input",
+    "ai-generate": "ai-generate",
     manual: "form",
   };
 
-  const handleMethodSelect = (method: "scan" | "manual" | "text-input") => {
+  const handleMethodSelect = (method: RecipeUploadMethod) => {
     setCurrentStep(stepMap[method]);
   };
 
@@ -67,6 +70,8 @@ export default function RecipeUploadContent({ tagCategories }: Props) {
       )}
 
       {currentStep === "text-input" && <TextInput handleTextInput={handleTextInput} />}
+
+      {currentStep === "ai-generate" && <AiRecipeGenerator />}
 
       {currentStep === "form" && (
         <RecipeForm

--- a/cook-scan/src/features/recipes/upload/recipe-upload-content.tsx
+++ b/cook-scan/src/features/recipes/upload/recipe-upload-content.tsx
@@ -71,7 +71,7 @@ export default function RecipeUploadContent({ tagCategories }: Props) {
 
       {currentStep === "text-input" && <TextInput handleTextInput={handleTextInput} />}
 
-      {currentStep === "ai-generate" && <AiRecipeGenerator />}
+      {currentStep === "ai-generate" && <AiRecipeGenerator tagCategories={tagCategories} />}
 
       {currentStep === "form" && (
         <RecipeForm


### PR DESCRIPTION
## Summary
- Add an AI recipe generation option to the recipe upload flow
- Add an interactive chat-style recipe generator UI
- Add a /api/recipes/generate endpoint backed by generateText
- Cover the new UI flow and API behavior with tests

## Tests
- vp check
- vp test