### PR TITLE
fix: reasoningモデル非対応のtemperatureパラメータを削除

### DIFF
--- a/cook-scan/src/app/api/recipes/extract/text/route.ts
+++ b/cook-scan/src/app/api/recipes/extract/text/route.ts
@@ -83,8 +83,7 @@ export async function POST(request: NextRequest) {
       schema: recipeSchema,
       system: systemPrompt,
       prompt: text,
-      temperature: 0,
-      topP: 0.1,
+      // gpt-5-mini is a reasoning model: temperature/topP are unsupported (only the default is allowed).
     });
 
     return NextResponse.json({ status: "success", result: object }, { status: 200 });

--- a/cook-scan/src/app/api/recipes/generate/route.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.ts
@@ -98,8 +98,7 @@ export async function POST(request: NextRequest) {
       schema: responseSchema,
       system: systemPrompt,
       prompt: buildConversationPrompt(body.messages),
-      // Keep enough variation for recipe ideation while schema validation keeps the output usable.
-      temperature: 0.7,
+      // gpt-5-mini is a reasoning model: temperature is unsupported (only the default is allowed).
     });
 
     return NextResponse.json(


### PR DESCRIPTION
## Summary

- `openaiGpt`（`gpt-5-mini-2025-08-07` = GPT-5系 reasoningモデル）に対して渡していた非対応パラメータを削除
  - `src/app/api/recipes/extract/text/route.ts`: `temperature: 0`, `topP: 0.1` を削除
  - `src/app/api/recipes/generate/route.ts`: `temperature: 0.7` を削除
- 各箇所に削除理由をコメントとして追記

## なぜ

OpenAI の reasoning モデル（o1/o3/o4-mini/GPT-5系）は `temperature` をサポートしておらず、デフォルト値（`1`）以外を指定すると `unsupported_value` で 400 エラーになる。`topP` などのサンプリング系パラメータも同様に非対応。本リポジトリは `gpt-5-mini` を利用しているため、これらのリクエストが実行時に失敗する潜在的なバグだった。

出力の決定論性・制御が必要な場合は、temperature ではなく `providerOptions.openai.reasoningEffort` 等で調整する。

## Test plan

- [x] \`pnpm run type-check\` passed
- [x] \`pnpm run lint\` passed
- [x] \`pnpm run test:run\`（generate route）passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)