### PR TITLE
fix: レシピAPIの入力検証と認証を強化する

### DIFF
--- a/cook-scan/src/app/api/recipes/extract/file/route.test.ts
+++ b/cook-scan/src/app/api/recipes/extract/file/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import type { NextRequest } from "next/server";
+import { checkUserProfile } from "@/features/auth/auth-utils";
+import { getSQSClient } from "@/lib/aws/sqs";
+
+vi.mock("@/features/auth/auth-utils", () => ({
+  checkUserProfile: vi.fn(),
+}));
+
+vi.mock("@/lib/aws/sqs", () => ({
+  getSQSClient: vi.fn(),
+}));
+
+// route はモジュール読み込み時に環境変数を評価するため、import 前に設定する。
+vi.stubEnv("AWS_SQS_QUEUE_URL", "https://sqs.example.com/queue");
+const { POST } = await import("./route");
+
+const VALID_JOB_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function buildRequest(body: unknown) {
+  return new Request("http://localhost/api/recipes/extract/file", {
+    method: "POST",
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe("POST /api/recipes/extract/file", () => {
+  const sqsSend = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkUserProfile).mockResolvedValue({
+      hasAuth: true,
+      hasProfile: true,
+      profile: { id: "user-1" },
+    } as Awaited<ReturnType<typeof checkUserProfile>>);
+    vi.mocked(getSQSClient).mockReturnValue({ send: sqsSend } as unknown as ReturnType<
+      typeof getSQSClient
+    >);
+  });
+
+  it("enqueues OCR job for valid UUID jobId", async () => {
+    sqsSend.mockResolvedValueOnce({});
+
+    const response = await POST(buildRequest({ jobId: VALID_JOB_ID }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, result: { jobId: VALID_JOB_ID } });
+    expect(sqsSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    vi.mocked(checkUserProfile).mockResolvedValue({
+      hasAuth: false,
+      hasProfile: false,
+      profile: null,
+    } as Awaited<ReturnType<typeof checkUserProfile>>);
+
+    const response = await POST(buildRequest({ jobId: VALID_JOB_ID }));
+
+    expect(response.status).toBe(401);
+    expect(sqsSend).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when jobId is missing", async () => {
+    const response = await POST(buildRequest({}));
+
+    expect(response.status).toBe(400);
+    expect(sqsSend).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when jobId is not a UUID", async () => {
+    const response = await POST(buildRequest({ jobId: "../other-user/job-1" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ success: false, error: "jobId が不正です" });
+    expect(sqsSend).not.toHaveBeenCalled();
+  });
+});

--- a/cook-scan/src/app/api/recipes/extract/file/route.ts
+++ b/cook-scan/src/app/api/recipes/extract/file/route.ts
@@ -2,8 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import { getSQSClient } from "@/lib/aws/sqs";
 import { checkUserProfile } from "@/features/auth/auth-utils";
+import { z } from "zod";
 
 const AWS_SQS_QUEUE_URL = process.env.AWS_SQS_QUEUE_URL;
+
+// presign ルートで randomUUID() により発行された値のみ受け付ける。
+// S3 プレフィックスに連結するため、パス断片などの混入をここで遮断する。
+const jobIdSchema = z.string().uuid();
 
 export async function POST(request: NextRequest) {
   try {
@@ -17,11 +22,12 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { jobId } = body;
+    const parsedJobId = jobIdSchema.safeParse(body.jobId);
 
-    if (typeof jobId !== "string" || !jobId) {
-      return NextResponse.json({ success: false, error: "jobId は必須です" }, { status: 400 });
+    if (!parsedJobId.success) {
+      return NextResponse.json({ success: false, error: "jobId が不正です" }, { status: 400 });
     }
+    const jobId = parsedJobId.data;
 
     const userId = profile.id;
     const s3Prefix = `uploads/${userId}/${jobId}/`;

--- a/cook-scan/src/app/api/recipes/extract/file/route.ts
+++ b/cook-scan/src/app/api/recipes/extract/file/route.ts
@@ -8,7 +8,7 @@ const AWS_SQS_QUEUE_URL = process.env.AWS_SQS_QUEUE_URL;
 
 // presign ルートで randomUUID() により発行された値のみ受け付ける。
 // S3 プレフィックスに連結するため、パス断片などの混入をここで遮断する。
-const jobIdSchema = z.string().uuid();
+const jobIdSchema = z.uuid();
 
 export async function POST(request: NextRequest) {
   try {

--- a/cook-scan/src/app/api/recipes/extract/result/route.test.ts
+++ b/cook-scan/src/app/api/recipes/extract/result/route.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import type { NextRequest } from "next/server";
+import { NextRequest as NextRequestImpl } from "next/server";
+import { checkUserProfile } from "@/features/auth/auth-utils";
+import { getS3Client } from "@/lib/aws/s3";
+
+vi.mock("@/features/auth/auth-utils", () => ({
+  checkUserProfile: vi.fn(),
+}));
+
+vi.mock("@/lib/aws/s3", () => ({
+  getS3Client: vi.fn(),
+}));
+
+// route はモジュール読み込み時に環境変数を評価するため、import 前に設定する。
+vi.stubEnv("S3_BUCKET_NAME", "test-bucket");
+const { GET } = await import("./route");
+
+const VALID_JOB_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function buildRequest(jobId?: string): NextRequest {
+  const url = new URL("http://localhost/api/recipes/extract/result");
+  if (jobId !== undefined) {
+    url.searchParams.set("jobId", jobId);
+  }
+  return new NextRequestImpl(url);
+}
+
+describe("GET /api/recipes/extract/result", () => {
+  const s3Send = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(checkUserProfile).mockResolvedValue({
+      hasAuth: true,
+      hasProfile: true,
+      profile: { id: "user-1" },
+    } as Awaited<ReturnType<typeof checkUserProfile>>);
+    vi.mocked(getS3Client).mockReturnValue({ send: s3Send } as unknown as ReturnType<
+      typeof getS3Client
+    >);
+  });
+
+  it("returns OCR result for valid UUID jobId", async () => {
+    s3Send.mockResolvedValueOnce({
+      Body: {
+        transformToString: () =>
+          Promise.resolve(
+            JSON.stringify({
+              status: "success",
+              jobId: VALID_JOB_ID,
+              processedAt: "2026-01-01T00:00:00Z",
+              result: { text: "抽出されたテキスト" },
+              error: null,
+            }),
+          ),
+      },
+    });
+
+    const response = await GET(buildRequest(VALID_JOB_ID));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: "success", result: { text: "抽出されたテキスト" } });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    vi.mocked(checkUserProfile).mockResolvedValue({
+      hasAuth: false,
+      hasProfile: false,
+      profile: null,
+    } as Awaited<ReturnType<typeof checkUserProfile>>);
+
+    const response = await GET(buildRequest(VALID_JOB_ID));
+
+    expect(response.status).toBe(401);
+    expect(s3Send).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when jobId is missing", async () => {
+    const response = await GET(buildRequest());
+
+    expect(response.status).toBe(400);
+    expect(s3Send).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when jobId is not a UUID", async () => {
+    const response = await GET(buildRequest("../../other-user/job-1"));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({ success: false, error: "jobId が不正です" });
+    expect(s3Send).not.toHaveBeenCalled();
+  });
+});

--- a/cook-scan/src/app/api/recipes/extract/result/route.ts
+++ b/cook-scan/src/app/api/recipes/extract/result/route.ts
@@ -2,8 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { getS3Client } from "@/lib/aws/s3";
 import { checkUserProfile } from "@/features/auth/auth-utils";
+import { z } from "zod";
 
 const S3_BUCKET_NAME = process.env.S3_BUCKET_NAME;
+
+// presign ルートで randomUUID() により発行された値のみ受け付ける。
+// S3 キーに連結するため、パス断片などの混入をここで遮断する。
+const jobIdSchema = z.string().uuid();
 
 export async function GET(request: NextRequest) {
   try {
@@ -12,10 +17,11 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ success: false, error: "認証が必要です" }, { status: 401 });
     }
 
-    const jobId = request.nextUrl.searchParams.get("jobId");
-    if (!jobId) {
-      return NextResponse.json({ success: false, error: "jobId は必須です" }, { status: 400 });
+    const parsedJobId = jobIdSchema.safeParse(request.nextUrl.searchParams.get("jobId"));
+    if (!parsedJobId.success) {
+      return NextResponse.json({ success: false, error: "jobId が不正です" }, { status: 400 });
     }
+    const jobId = parsedJobId.data;
 
     if (!S3_BUCKET_NAME) {
       throw new Error("環境変数 AWS_S3_BUCKET_NAME が設定されていません");

--- a/cook-scan/src/app/api/recipes/extract/result/route.ts
+++ b/cook-scan/src/app/api/recipes/extract/result/route.ts
@@ -8,7 +8,7 @@ const S3_BUCKET_NAME = process.env.S3_BUCKET_NAME;
 
 // presign ルートで randomUUID() により発行された値のみ受け付ける。
 // S3 キーに連結するため、パス断片などの混入をここで遮断する。
-const jobIdSchema = z.string().uuid();
+const jobIdSchema = z.uuid();
 
 export async function GET(request: NextRequest) {
   try {

--- a/cook-scan/src/app/api/recipes/extract/text/route.test.ts
+++ b/cook-scan/src/app/api/recipes/extract/text/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
+import type { NextRequest } from "next/server";
+import { generateObject } from "ai";
+import { checkUserProfile } from "@/features/auth/auth-utils";
+import { POST } from "./route";
+
+vi.mock("ai", () => ({
+  generateObject: vi.fn(),
+}));
+
+vi.mock("@/backend/ai/models/openai", () => ({
+  openaiGpt: "mock-openai-model",
+}));
+
+vi.mock("@/features/auth/auth-utils", () => ({
+  checkUserProfile: vi.fn(),
+}));
+
+function buildRequest(body: unknown) {
+  return new Request("http://localhost/api/recipes/extract/text", {
+    method: "POST",
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe("POST /api/recipes/extract/text", () => {
+  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // デフォルトは認証済みユーザー。未認証ケースは各テストで上書きする。
+    vi.mocked(checkUserProfile).mockResolvedValue({
+      hasAuth: true,
+      hasProfile: true,
+      profile: { id: "user-1" },
+    } as Awaited<ReturnType<typeof checkUserProfile>>);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockClear();
+  });
+
+  it("returns extracted recipe for valid text", async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce({
+      object: {
+        title: "卵チャーハン",
+        ingredients: [{ name: "卵", unit: "1個", notes: null }],
+        steps: [{ instruction: "卵を炒める", timerSeconds: null }],
+        memo: null,
+      },
+    } as Awaited<ReturnType<typeof generateObject>>);
+
+    const response = await POST(buildRequest({ text: "卵チャーハンのレシピ。卵を炒める。" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("success");
+    expect(body.result.title).toBe("卵チャーハン");
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    vi.mocked(checkUserProfile).mockResolvedValue({
+      hasAuth: false,
+      hasProfile: false,
+      profile: null,
+    } as Awaited<ReturnType<typeof checkUserProfile>>);
+
+    const response = await POST(buildRequest({ text: "卵チャーハンのレシピ" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body).toEqual({ status: "error", error: "認証が必要です" });
+    expect(generateObject).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when text is missing", async () => {
+    const response = await POST(buildRequest({}));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.status).toBe("error");
+    expect(generateObject).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when text is empty", async () => {
+    const response = await POST(buildRequest({ text: "   " }));
+
+    expect(response.status).toBe(400);
+    expect(generateObject).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when text exceeds max length", async () => {
+    const response = await POST(buildRequest({ text: "あ".repeat(20001) }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("20000文字以内");
+    expect(generateObject).not.toHaveBeenCalled();
+  });
+});

--- a/cook-scan/src/app/api/recipes/extract/text/route.ts
+++ b/cook-scan/src/app/api/recipes/extract/text/route.ts
@@ -1,7 +1,18 @@
 import { openaiGpt } from "@/backend/ai/models/openai";
+import { checkUserProfile } from "@/features/auth/auth-utils";
 import { generateObject } from "ai";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
+
+const MAX_TEXT_LENGTH = 20000;
+
+const requestSchema = z.object({
+  text: z
+    .string()
+    .trim()
+    .min(1, "textは必須です")
+    .max(MAX_TEXT_LENGTH, `textは${MAX_TEXT_LENGTH}文字以内で指定してください`),
+});
 
 const recipeSchema = z.object({
   title: z.string(),
@@ -71,12 +82,19 @@ const systemPrompt = `
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { text } = body;
-
-    if (!text || typeof text !== "string") {
-      return NextResponse.json({ status: "error", error: "textは必須です" }, { status: 400 });
+    const { hasAuth, hasProfile, profile } = await checkUserProfile();
+    if (!hasAuth || !hasProfile || !profile) {
+      return NextResponse.json({ status: "error", error: "認証が必要です" }, { status: 401 });
     }
+
+    const parsed = requestSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { status: "error", error: parsed.error.issues[0]?.message ?? "textは必須です" },
+        { status: 400 },
+      );
+    }
+    const { text } = parsed.data;
 
     const { object } = await generateObject({
       model: openaiGpt,

--- a/cook-scan/src/app/api/recipes/generate/route.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.ts
@@ -36,7 +36,7 @@ const requestSchema = z.object({
       message: "最後のメッセージはuserである必要があります",
     }),
   referenceRecipeIds: z
-    .array(z.string().uuid())
+    .array(z.uuid())
     .max(MAX_REFERENCE_RECIPE_COUNT, `参照レシピは${MAX_REFERENCE_RECIPE_COUNT}件までです`)
     .optional(),
 });

--- a/cook-scan/src/app/api/recipes/generate/route.ts
+++ b/cook-scan/src/app/api/recipes/generate/route.ts
@@ -10,6 +10,10 @@ const USER_ROLE = "user";
 const ASSISTANT_ROLE = "assistant";
 const MESSAGE_ROLES = [USER_ROLE, ASSISTANT_ROLE] as const;
 const MAX_SUGGESTION_COUNT = 4;
+// 参照レシピ全文やレシピ下書きが履歴に焼き込まれるため、1メッセージの上限は余裕を持たせる。
+const MAX_MESSAGE_LENGTH = 20000;
+const MAX_MESSAGE_COUNT = 50;
+const MAX_REFERENCE_RECIPE_COUNT = 10;
 
 // 参照レシピが見つからなかった場合に投げる識別用エラー。
 class ReferenceRecipeNotFoundError extends Error {}
@@ -19,14 +23,22 @@ const requestSchema = z.object({
     .array(
       z.object({
         role: z.enum(MESSAGE_ROLES),
-        content: z.string().trim().min(1),
+        content: z
+          .string()
+          .trim()
+          .min(1)
+          .max(MAX_MESSAGE_LENGTH, `メッセージは${MAX_MESSAGE_LENGTH}文字以内で入力してください`),
       }),
     )
     .min(1, "messagesは1件以上必要です")
+    .max(MAX_MESSAGE_COUNT, `messagesは${MAX_MESSAGE_COUNT}件以内にしてください`)
     .refine((messages) => messages[messages.length - 1]?.role === USER_ROLE, {
       message: "最後のメッセージはuserである必要があります",
     }),
-  referenceRecipeIds: z.array(z.string().uuid()).optional(),
+  referenceRecipeIds: z
+    .array(z.string().uuid())
+    .max(MAX_REFERENCE_RECIPE_COUNT, `参照レシピは${MAX_REFERENCE_RECIPE_COUNT}件までです`)
+    .optional(),
 });
 
 const recipeDraftSchema = z.object({

--- a/cook-scan/src/features/recipes/edit/actions.ts
+++ b/cook-scan/src/features/recipes/edit/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { UpdateRecipeRequest } from "@/features/recipes/edit/types";
 import * as RecipeService from "@/backend/services/recipes";
+import { updateRecipeInputSchema } from "@/backend/domain/recipes";
 import type { Result } from "@/utils/result";
 import { success, failure, Errors } from "@/utils/result";
 import { withAuth } from "@/utils/server-action";
@@ -11,8 +12,13 @@ export async function updateRecipe(
   request: UpdateRecipeRequest,
 ): Promise<Result<{ recipeId: string }>> {
   return withAuth(async (profile) => {
+    const validation = updateRecipeInputSchema.safeParse(request);
+    if (!validation.success) {
+      return failure(Errors.validation(validation.error.issues[0].message));
+    }
+
     try {
-      const result = await RecipeService.updateRecipe(profile.id, request);
+      const result = await RecipeService.updateRecipe(profile.id, validation.data);
 
       // Revalidate recipe list and detail pages
       revalidatePath("/recipes");

--- a/cook-scan/src/features/recipes/upload/actions.ts
+++ b/cook-scan/src/features/recipes/upload/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { CreateRecipeRequest } from "@/features/recipes/upload/types";
 import * as RecipeService from "@/backend/services/recipes";
+import { createRecipeInputSchema } from "@/backend/domain/recipes";
 import type { Result } from "@/utils/result";
 import { success, failure, Errors } from "@/utils/result";
 import { withAuth } from "@/utils/server-action";
@@ -11,8 +12,13 @@ export async function createRecipe(
   request: CreateRecipeRequest,
 ): Promise<Result<{ recipeId: string }>> {
   return withAuth(async (profile) => {
+    const validation = createRecipeInputSchema.safeParse(request);
+    if (!validation.success) {
+      return failure(Errors.validation(validation.error.issues[0].message));
+    }
+
     try {
-      const result = await RecipeService.createRecipe(profile.id, request);
+      const result = await RecipeService.createRecipe(profile.id, validation.data);
 
       // Revalidate recipe list and detail pages
       revalidatePath("/recipes");


### PR DESCRIPTION
## Summary
- extract/file・result で `jobId` を UUID のみ受け付け、S3 パス断片の混入を遮断
- extract/text に認証と文字数上限を追加し、未認証・過大入力によるコスト肥大化を防ぐ
- generate API にメッセージ長・件数・参照レシピ件数の上限を追加し、create/update ではドメインスキーマでサーバ側検証を行う

## Test plan
- [ ] `vp test src/app/api/recipes/extract/file/route.test.ts src/app/api/recipes/extract/result/route.test.ts src/app/api/recipes/extract/text/route.test.ts --run` が通る
- [ ] 画像アップロード〜OCR〜テキスト抽出の一連フローが認証済みユーザーで成功する
- [ ] 不正な `jobId`（パス断片など）で extract/file・result が 400 を返す
- [ ] 未認証で extract/text が 401 を返す
- [ ] レシピ作成・更新で空タイトルなど不正入力がバリデーションエラーになる
- [ ] AIレシピ生成で通常の会話・参照レシピが問題なく動く


Made with [Cursor](https://cursor.com)